### PR TITLE
feat: default to serve command when no args provided

### DIFF
--- a/cmd/otlp-mcp/main.go
+++ b/cmd/otlp-mcp/main.go
@@ -12,12 +12,17 @@ import (
 const version = "0.3.0"
 
 func main() {
+	serveCmd := cli.ServeCommand()
+
 	app := &cliframework.Command{
 		Name:    "otlp-mcp",
 		Usage:   "OTLP MCP server for AI agent observability",
 		Version: version,
+		// Default to serve when no subcommand provided
+		Action: serveCmd.Action,
+		Flags:  serveCmd.Flags,
 		Commands: []*cliframework.Command{
-			cli.ServeCommand(),
+			serveCmd,
 			cli.DoctorCommand(version),
 		},
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -55,9 +55,8 @@ data via MCP tools.`,
 				Value: -1, // -1 means not set
 			},
 			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Usage:   "Enable verbose logging (overrides config file)",
+				Name:  "verbose",
+				Usage: "Enable verbose logging (overrides config file)",
 			},
 		},
 		Action: runServe,


### PR DESCRIPTION
## Why
Make otlp-mcp easier to start using - simplify UX and documentation for new users

## Approach
- Default to serve command (no args needed)
- Comprehensive README refactor for beginners
- Support both Claude Code and Gemini CLI equally

## Learned
- Removed -v alias from --verbose (conflicts with --version)
- Quick Start was 169 lines - way too long for new users
- Documentation was Claude Code-centric, needed generic language

## Changes

### Code
- ✅ `serve` is now default command when no args provided
- ✅ All serve flags available as global options
- ✅ Fixed -v conflict between --verbose and --version

### Documentation
- ✅ **Quick Start: 169 → 50 lines** (moved advanced config to new section)
- ✅ Added "Advanced Configuration" section with all details
- ✅ Generic language supporting both Claude Code and Gemini CLI
- ✅ Consistent `$(go env GOPATH)/bin/otlp-mcp` pattern throughout
- ✅ Streamlined config examples

### New User Experience

**Before:**
```bash
# Install
git clone https://github.com/tobert/otlp-mcp.git
cd otlp-mcp
go build -o otlp-mcp ./cmd/otlp-mcp

# Configure (manual JSON editing with long path)
{
  "mcpServers": {
    "otlp-mcp": {
      "command": "/absolute/path/to/otlp-mcp/otlp-mcp",
      "args": ["serve", "--verbose"]
    }
  }
}
```

**After:**
```bash
# Install
go install github.com/tobert/otlp-mcp/cmd/otlp-mcp@latest

# Configure (one command!)
claude mcp add otlp-mcp $(go env GOPATH)/bin/otlp-mcp
# or
gemini mcp add otlp-mcp $(go env GOPATH)/bin/otlp-mcp
```

### README Structure
```
Quick Start (streamlined!)
├── Install (go install)
├── Configure (Claude | Gemini | Manual)
└── Verify

MCP Tools

Workflow Examples (now generic)

Advanced Configuration (NEW!)
├── Build from Source
├── Stable Ports for Watch Workflows
├── Configuration Files
└── Command-Line Options

Demo
Troubleshooting (now generic)
```

Co-Authored-By: Claude <claude@anthropic.com>