### PR TITLE
feat: add filesystem source for reading OTLP from collector file exports

### DIFF
--- a/examples/otelcol-file-exporter.yaml
+++ b/examples/otelcol-file-exporter.yaml
@@ -1,0 +1,68 @@
+# Example OpenTelemetry Collector configuration for file export
+#
+# This config receives OTLP telemetry and writes it to JSONL files that
+# otlp-mcp can read via the set_file_source MCP tool or --file-source flag.
+#
+# Install: Copy to /etc/otelcol/config.yaml (or use --config flag)
+# Usage:   systemctl start otelcol
+#          otlp-mcp --file-source /var/lib/otel
+#
+# The collector listens on standard OTLP ports:
+#   - gRPC: localhost:4317
+#   - HTTP: localhost:4318
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 2s
+
+exporters:
+  # File exporter for traces
+  file/traces:
+    path: /var/lib/otel/traces/traces.jsonl
+    rotation:
+      max_megabytes: 100
+      max_days: 30
+      max_backups: 50
+    format: json
+
+  # File exporter for logs
+  file/logs:
+    path: /var/lib/otel/logs/logs.jsonl
+    rotation:
+      max_megabytes: 100
+      max_days: 30
+      max_backups: 50
+    format: json
+
+  # File exporter for metrics
+  file/metrics:
+    path: /var/lib/otel/metrics/metrics.jsonl
+    rotation:
+      max_megabytes: 100
+      max_days: 30
+      max_backups: 50
+    format: json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/traces]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/metrics]

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/tobert/otlp-mcp
 go 1.25
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.5.0
 	go.opentelemetry.io/proto/otlp v1.9.0
 	google.golang.org/grpc v1.76.0
+	google.golang.org/protobuf v1.36.10
 )
 
 require (
@@ -24,6 +26,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/filereader/filereader.go
+++ b/internal/filereader/filereader.go
@@ -1,0 +1,404 @@
+// Package filereader reads OTLP telemetry from JSONL files written by the
+// OpenTelemetry Collector's file exporter. It feeds data into the same ring
+// buffers used by the TCP receiver, so all query/snapshot logic works unchanged.
+package filereader
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+const (
+	// Buffer sizes for JSONL line scanning. OTLP JSON can be large,
+	// especially for batched spans with many attributes.
+	jsonlBufferInitial = 1 * 1024 * 1024  // 1MB initial buffer
+	jsonlBufferMax     = 10 * 1024 * 1024 // 10MB maximum line size
+)
+
+// StorageReceiver is the interface that storage must implement to receive telemetry.
+// This matches the methods on ObservabilityStorage.
+type StorageReceiver interface {
+	ReceiveSpans(ctx context.Context, resourceSpans []*tracepb.ResourceSpans) error
+	ReceiveLogs(ctx context.Context, resourceLogs []*logspb.ResourceLogs) error
+	ReceiveMetrics(ctx context.Context, resourceMetrics []*metricspb.ResourceMetrics) error
+}
+
+// FileSource reads OTLP telemetry from a directory of JSONL files.
+// It watches for new data and feeds it into the storage ring buffers.
+type FileSource struct {
+	directory string
+	storage   StorageReceiver
+	verbose   bool
+
+	watcher *fsnotify.Watcher
+
+	// Track file read positions to only read new data
+	mu          sync.Mutex
+	fileOffsets map[string]int64
+
+	// Control
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// Config holds configuration for a FileSource.
+type Config struct {
+	Directory string // Base directory (e.g., /tank/otel)
+	Verbose   bool   // Enable verbose logging
+
+	// Optional: time cutoff - only load data newer than this
+	// Zero value means load everything
+	SinceTime time.Time
+}
+
+// New creates a new FileSource that reads from the given directory.
+// The directory should contain subdirectories: traces/, logs/, metrics/
+// with .jsonl files inside them.
+func New(cfg Config, storage StorageReceiver) (*FileSource, error) {
+	if cfg.Directory == "" {
+		return nil, fmt.Errorf("directory is required")
+	}
+
+	// Verify directory exists
+	info, err := os.Stat(cfg.Directory)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access directory %s: %w", cfg.Directory, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", cfg.Directory)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &FileSource{
+		directory:   cfg.Directory,
+		storage:     storage,
+		verbose:     cfg.Verbose,
+		watcher:     watcher,
+		fileOffsets: make(map[string]int64),
+		ctx:         ctx,
+		cancel:      cancel,
+	}, nil
+}
+
+// Start begins watching the directory and loading initial data.
+// It returns after initial load completes; watching continues in background.
+func (fs *FileSource) Start(ctx context.Context) error {
+	if fs.verbose {
+		log.Printf("📁 FileSource: starting with directory %s\n", fs.directory)
+	}
+
+	// Set up watches on signal subdirectories
+	signals := []string{"traces", "logs", "metrics"}
+	for _, signal := range signals {
+		dir := filepath.Join(fs.directory, signal)
+		if _, err := os.Stat(dir); err == nil {
+			if err := fs.watcher.Add(dir); err != nil {
+				log.Printf("⚠️  FileSource: could not watch %s: %v\n", dir, err)
+			} else if fs.verbose {
+				log.Printf("📁 FileSource: watching %s\n", dir)
+			}
+		}
+	}
+
+	// Initial load of existing files
+	if err := fs.loadInitialData(ctx); err != nil {
+		return fmt.Errorf("initial data load failed: %w", err)
+	}
+
+	// Start background watcher
+	fs.wg.Add(1)
+	go fs.watchLoop()
+
+	return nil
+}
+
+// Stop stops the file watcher and waits for goroutines to finish.
+func (fs *FileSource) Stop() {
+	fs.cancel()
+	fs.watcher.Close()
+	fs.wg.Wait()
+}
+
+// Directory returns the base directory being watched.
+func (fs *FileSource) Directory() string {
+	return fs.directory
+}
+
+// loadInitialData reads all existing JSONL files into storage.
+func (fs *FileSource) loadInitialData(ctx context.Context) error {
+	signals := []struct {
+		name   string
+		loader func(context.Context, string) (int, error)
+	}{
+		{"traces", fs.loadTraceFile},
+		{"logs", fs.loadLogFile},
+		{"metrics", fs.loadMetricFile},
+	}
+
+	for _, sig := range signals {
+		dir := filepath.Join(fs.directory, sig.name)
+		files, err := fs.findJSONLFiles(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // Signal directory doesn't exist, skip
+			}
+			return err
+		}
+
+		for _, file := range files {
+			count, err := sig.loader(ctx, file)
+			if err != nil {
+				log.Printf("⚠️  FileSource: error loading %s: %v\n", file, err)
+				continue
+			}
+			if fs.verbose && count > 0 {
+				log.Printf("📁 FileSource: loaded %d %s from %s\n", count, sig.name, filepath.Base(file))
+			}
+		}
+	}
+
+	return nil
+}
+
+// findJSONLFiles returns all .jsonl files in a directory, sorted by modification time.
+func (fs *FileSource) findJSONLFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	type fileInfo struct {
+		path    string
+		modTime time.Time
+	}
+	var files []fileInfo
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".jsonl") || strings.Contains(name, ".jsonl.") {
+			path := filepath.Join(dir, name)
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			files = append(files, fileInfo{path: path, modTime: info.ModTime()})
+		}
+	}
+
+	// Sort by modification time (oldest first) so we load data in chronological order
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime.Before(files[j].modTime)
+	})
+
+	result := make([]string, len(files))
+	for i, f := range files {
+		result[i] = f.path
+	}
+	return result, nil
+}
+
+// loadTraceFile reads a JSONL file containing traces and feeds them to storage.
+func (fs *FileSource) loadTraceFile(ctx context.Context, path string) (int, error) {
+	return fs.processFile(ctx, path, func(line []byte) error {
+		var data tracepb.TracesData
+		if err := protojson.Unmarshal(line, &data); err != nil {
+			return fmt.Errorf("parse trace JSON: %w", err)
+		}
+		if len(data.ResourceSpans) > 0 {
+			return fs.storage.ReceiveSpans(ctx, data.ResourceSpans)
+		}
+		return nil
+	})
+}
+
+// loadLogFile reads a JSONL file containing logs and feeds them to storage.
+func (fs *FileSource) loadLogFile(ctx context.Context, path string) (int, error) {
+	return fs.processFile(ctx, path, func(line []byte) error {
+		var data logspb.LogsData
+		if err := protojson.Unmarshal(line, &data); err != nil {
+			return fmt.Errorf("parse log JSON: %w", err)
+		}
+		if len(data.ResourceLogs) > 0 {
+			return fs.storage.ReceiveLogs(ctx, data.ResourceLogs)
+		}
+		return nil
+	})
+}
+
+// loadMetricFile reads a JSONL file containing metrics and feeds them to storage.
+func (fs *FileSource) loadMetricFile(ctx context.Context, path string) (int, error) {
+	return fs.processFile(ctx, path, func(line []byte) error {
+		var data metricspb.MetricsData
+		if err := protojson.Unmarshal(line, &data); err != nil {
+			return fmt.Errorf("parse metric JSON: %w", err)
+		}
+		if len(data.ResourceMetrics) > 0 {
+			return fs.storage.ReceiveMetrics(ctx, data.ResourceMetrics)
+		}
+		return nil
+	})
+}
+
+// processFile reads a JSONL file from the last known offset, calling handler for each line.
+// Returns the number of lines processed.
+func (fs *FileSource) processFile(ctx context.Context, path string, handler func([]byte) error) (int, error) {
+	fs.mu.Lock()
+	offset := fs.fileOffsets[path]
+	fs.mu.Unlock()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	// Seek to last read position
+	if offset > 0 {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			// File might have been rotated, start from beginning
+			offset = 0
+		}
+	}
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, jsonlBufferInitial)
+	scanner.Buffer(buf, jsonlBufferMax)
+
+	count := 0
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return count, ctx.Err()
+		default:
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		if err := handler(line); err != nil {
+			// Log but continue - don't let one bad line stop everything
+			if fs.verbose {
+				log.Printf("⚠️  FileSource: error processing line in %s: %v\n", filepath.Base(path), err)
+			}
+			continue
+		}
+		count++
+	}
+
+	if err := scanner.Err(); err != nil {
+		return count, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// Update offset
+	newOffset, _ := file.Seek(0, io.SeekCurrent)
+	fs.mu.Lock()
+	fs.fileOffsets[path] = newOffset
+	fs.mu.Unlock()
+
+	return count, nil
+}
+
+// watchLoop runs the file watcher event loop.
+func (fs *FileSource) watchLoop() {
+	defer fs.wg.Done()
+
+	for {
+		select {
+		case <-fs.ctx.Done():
+			return
+
+		case event, ok := <-fs.watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Only care about writes and creates
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+
+			// Determine signal type from path
+			path := event.Name
+			if !strings.HasSuffix(path, ".jsonl") && !strings.Contains(path, ".jsonl.") {
+				continue
+			}
+
+			dir := filepath.Dir(path)
+			signal := filepath.Base(dir)
+
+			ctx, cancel := context.WithTimeout(fs.ctx, 30*time.Second)
+
+			var count int
+			var err error
+			switch signal {
+			case "traces":
+				count, err = fs.loadTraceFile(ctx, path)
+			case "logs":
+				count, err = fs.loadLogFile(ctx, path)
+			case "metrics":
+				count, err = fs.loadMetricFile(ctx, path)
+			}
+			cancel()
+
+			if err != nil {
+				log.Printf("⚠️  FileSource: error reading %s: %v\n", path, err)
+			} else if fs.verbose && count > 0 {
+				log.Printf("📁 FileSource: loaded %d new %s from %s\n", count, signal, filepath.Base(path))
+			}
+
+		case err, ok := <-fs.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("⚠️  FileSource: watcher error: %v\n", err)
+		}
+	}
+}
+
+// Stats returns statistics about the file source.
+type Stats struct {
+	Directory    string   `json:"directory"`
+	WatchedDirs  []string `json:"watched_dirs"`
+	FilesTracked int      `json:"files_tracked"`
+}
+
+// Stats returns current statistics.
+func (fs *FileSource) Stats() Stats {
+	fs.mu.Lock()
+	filesTracked := len(fs.fileOffsets)
+	fs.mu.Unlock()
+
+	return Stats{
+		Directory:    fs.directory,
+		WatchedDirs:  fs.watcher.WatchList(),
+		FilesTracked: filesTracked,
+	}
+}


### PR DESCRIPTION
## Summary

Adds a filesystem mode that reads OTLP telemetry from JSONL files written by the OpenTelemetry Collector's file exporter. This complements live TCP ingest for:

- Analyzing historical telemetry already on disk
- Environments where the collector is the central ingestion point
- Debugging without reconfiguring applications

## Changes

- **New package `internal/filereader/`**: Parses OTLP JSONL, watches with fsnotify, feeds into ring buffers
- **3 new MCP tools**: `set_file_source`, `remove_file_source`, `list_file_sources`
- **CLI flag**: `--file-source / -f` for startup configuration
- **Example config**: `examples/otelcol-file-exporter.yaml`

## Usage

```bash
# Via CLI flag
otlp-mcp --file-source /var/lib/otel

# Via MCP tool
set_file_source({directory: "/var/lib/otel"})
```

The directory should contain `traces/`, `logs/`, and/or `metrics/` subdirectories with `.jsonl` files.

## Test Plan

- [x] Build succeeds
- [x] All existing tests pass
- [x] Verified traces load from filesystem
- [x] Verified fsnotify picks up new traces written by collector

Co-Authored-By: Claude <claude@anthropic.com>