### PR TITLE
feat: add HTTP transport and otel-config integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,5 +27,4 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cli/otelconfig.go
+++ b/internal/cli/otelconfig.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OtelCollectorConfig represents the relevant parts of an OpenTelemetry Collector config.
+// We only parse the exporters section to find file exporters.
+type OtelCollectorConfig struct {
+	Exporters map[string]FileExporter `yaml:"exporters"`
+}
+
+// FileExporter represents a file exporter configuration.
+type FileExporter struct {
+	Path string `yaml:"path"`
+}
+
+// ParseOtelConfig reads an OpenTelemetry Collector config file and extracts
+// directories from file exporter paths. It looks for exporters with names
+// starting with "file/" and returns the parent directories of their paths.
+func ParseOtelConfig(configPath string) ([]string, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read otel config: %w", err)
+	}
+
+	var config OtelCollectorConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse otel config: %w", err)
+	}
+
+	// Collect unique directories from file exporters
+	dirSet := make(map[string]struct{})
+	for name, exporter := range config.Exporters {
+		if strings.HasPrefix(name, "file/") && exporter.Path != "" {
+			dir := filepath.Dir(exporter.Path)
+			dirSet[dir] = struct{}{}
+		}
+	}
+
+	// Convert to slice
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+
+	return dirs, nil
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
+	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tobert/otlp-mcp/internal/mcpserver"
 	"github.com/tobert/otlp-mcp/internal/otlpreceiver"
 	"github.com/tobert/otlp-mcp/internal/storage"
@@ -21,8 +25,16 @@ func ServeCommand() *cli.Command {
 		Name:  "serve",
 		Usage: "Start the OTLP receiver and MCP server",
 		Description: `Starts an OTLP gRPC receiver on localhost:0 (ephemeral port) and an
-MCP server on stdio. The agent can query the OTLP endpoint and trace
-data via MCP tools.`,
+MCP server on stdio (default) or HTTP.
+
+Transport modes:
+  stdio  - MCP over stdin/stdout (default, for agent spawned processes)
+  http   - MCP over Streamable HTTP at /mcp (for persistent services)
+
+Examples:
+  otlp-mcp serve                        # stdio mode (default)
+  otlp-mcp serve --transport http       # HTTP mode on port 4380
+  otlp-mcp serve --transport http --http-port 8080`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "config",
@@ -63,6 +75,40 @@ data via MCP tools.`,
 				Aliases: []string{"f"},
 				Usage:   "Directory to load OTLP JSONL files from (can be specified multiple times)",
 			},
+			// HTTP transport flags
+			&cli.StringFlag{
+				Name:  "transport",
+				Usage: "MCP transport: 'stdio' (default) or 'http'",
+				Value: "",
+			},
+			&cli.StringFlag{
+				Name:  "http-host",
+				Usage: "HTTP server bind address (when transport=http)",
+				Value: "",
+			},
+			&cli.IntFlag{
+				Name:  "http-port",
+				Usage: "HTTP server port (when transport=http, default 4380)",
+				Value: -1,
+			},
+			&cli.StringSliceFlag{
+				Name:  "allowed-origin",
+				Usage: "Allowed Origin headers for HTTP transport (can specify multiple)",
+			},
+			&cli.DurationFlag{
+				Name:  "session-timeout",
+				Usage: "Session idle timeout for HTTP transport (e.g., 30m)",
+				Value: 0,
+			},
+			&cli.BoolFlag{
+				Name:  "stateless",
+				Usage: "Run HTTP transport in stateless mode (no session persistence)",
+			},
+			// Otel collector integration
+			&cli.StringFlag{
+				Name:  "otel-config",
+				Usage: "Path to otel-collector config.yaml to auto-discover file sources (skips OTLP listener)",
+			},
 		},
 		Action: runServe,
 	}
@@ -98,6 +144,26 @@ func runServe(cliCtx context.Context, cmd *cli.Command) error {
 		cfg.Verbose = cmd.Bool("verbose")
 	}
 
+	// Apply HTTP transport flag overrides
+	if transport := cmd.String("transport"); transport != "" {
+		cfg.Transport = transport
+	}
+	if httpHost := cmd.String("http-host"); httpHost != "" {
+		cfg.HTTPHost = httpHost
+	}
+	if httpPort := cmd.Int("http-port"); httpPort > 0 {
+		cfg.HTTPPort = httpPort
+	}
+	if origins := cmd.StringSlice("allowed-origin"); len(origins) > 0 {
+		cfg.AllowedOrigins = origins
+	}
+	if timeout := cmd.Duration("session-timeout"); timeout > 0 {
+		cfg.SessionTimeout = timeout.String()
+	}
+	if cmd.IsSet("stateless") {
+		cfg.Stateless = cmd.Bool("stateless")
+	}
+
 	if cfg.Verbose {
 		log.Println("🔧 Configuration:")
 		if configPath != "" {
@@ -130,43 +196,69 @@ func runServe(cliCtx context.Context, cmd *cli.Command) error {
 		log.Printf("   Metric buffer: %d points\n", cfg.MetricBufferSize)
 	}
 
-	// 2. Create and start unified OTLP gRPC receiver (all signals on one port)
+	// Check if we're using otel-config mode (file sources only, no OTLP listener by default)
+	otelConfigPath := cmd.String("otel-config")
+	useOtelConfig := otelConfigPath != ""
+
+	// 2. Create context for lifecycle management
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Create unified receiver for all signal types
-	otlpServer, err := otlpreceiver.NewUnifiedServer(
-		otlpreceiver.Config{
-			Host: cfg.OTLPHost,
-			Port: cfg.OTLPPort,
-		},
-		obsStorage, // Implements ReceiveSpans, ReceiveLogs, ReceiveMetrics
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create OTLP receiver: %w", err)
-	}
-
-	// Start receiver in background
+	// 3. Create and optionally start unified OTLP gRPC receiver
+	var otlpServer *otlpreceiver.UnifiedServer
 	otlpErrChan := make(chan error, 1)
-	go func() {
-		otlpErrChan <- otlpServer.Start(ctx)
-	}()
 
-	// Get the actual endpoint (important for ephemeral ports)
-	endpoint := otlpServer.Endpoint()
+	if useOtelConfig {
+		// When using otel-config, create receiver but don't start it
+		// Agent can use add_otlp_port if they need live OTLP ingestion
+		var err error
+		otlpServer, err = otlpreceiver.NewUnifiedServer(
+			otlpreceiver.Config{
+				Host: cfg.OTLPHost,
+				Port: cfg.OTLPPort,
+			},
+			obsStorage,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create OTLP receiver: %w", err)
+		}
+		log.Println("📁 Using file sources from otel-collector config (OTLP listener disabled)")
+		log.Println("   💡 Use add_otlp_port tool to enable live OTLP ingestion if needed")
+	} else {
+		// Normal mode: create and start OTLP receiver
+		var err error
+		otlpServer, err = otlpreceiver.NewUnifiedServer(
+			otlpreceiver.Config{
+				Host: cfg.OTLPHost,
+				Port: cfg.OTLPPort,
+			},
+			obsStorage,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create OTLP receiver: %w", err)
+		}
 
-	log.Printf("🌐 OTLP gRPC receiver listening on: %s\n", endpoint)
-	log.Printf("   📡 Accepting: traces, logs, and metrics\n")
-	if cfg.Verbose {
-		log.Printf("\n   Programs can send all telemetry with:\n")
-		log.Printf("   OTEL_EXPORTER_OTLP_ENDPOINT=%s\n", endpoint)
-		log.Printf("\n   Or per-signal (all use same endpoint):\n")
-		log.Printf("   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=%s\n", endpoint)
-		log.Printf("   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=%s\n", endpoint)
-		log.Printf("   OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=%s\n", endpoint)
+		// Start receiver in background
+		go func() {
+			otlpErrChan <- otlpServer.Start(ctx)
+		}()
+
+		// Get the actual endpoint (important for ephemeral ports)
+		endpoint := otlpServer.Endpoint()
+
+		log.Printf("🌐 OTLP gRPC receiver listening on: %s\n", endpoint)
+		log.Printf("   📡 Accepting: traces, logs, and metrics\n")
+		if cfg.Verbose {
+			log.Printf("\n   Programs can send all telemetry with:\n")
+			log.Printf("   OTEL_EXPORTER_OTLP_ENDPOINT=%s\n", endpoint)
+			log.Printf("\n   Or per-signal (all use same endpoint):\n")
+			log.Printf("   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=%s\n", endpoint)
+			log.Printf("   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=%s\n", endpoint)
+			log.Printf("   OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=%s\n", endpoint)
+		}
 	}
 
-	// 3. Create MCP server with unified storage and receiver
+	// 4. Create MCP server with unified storage and receiver
 	mcpServer, err := mcpserver.NewServer(obsStorage, otlpServer, mcpserver.ServerOptions{
 		Verbose: cfg.Verbose,
 	})
@@ -200,7 +292,22 @@ func runServe(cliCtx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	// 5. Setup graceful shutdown on SIGINT/SIGTERM
+	// 5. Load file sources from otel-collector config
+	if useOtelConfig {
+		dirs, err := ParseOtelConfig(otelConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to parse otel config %s: %w", otelConfigPath, err)
+		}
+		for _, dir := range dirs {
+			if err := mcpServer.AddFileSource(ctx, dir); err != nil {
+				log.Printf("⚠️  Failed to add file source %s: %v\n", dir, err)
+			} else {
+				log.Printf("📁 Auto-discovered file source: %s\n", dir)
+			}
+		}
+	}
+
+	// 6. Setup graceful shutdown on SIGINT/SIGTERM
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
@@ -210,27 +317,178 @@ func runServe(cliCtx context.Context, cmd *cli.Command) error {
 			log.Printf("📡 Received signal %v, initiating graceful shutdown...\n", sig)
 		}
 		cancel()
-		otlpServer.Stop()
+		if !useOtelConfig {
+			otlpServer.Stop()
+		}
 	}()
 
-	// 6. Run MCP server on stdio (blocks until stdin closes or context cancelled)
-	log.Println("🎯 MCP server ready on stdio")
-	log.Println("💡 Use MCP tools to query traces and get the OTLP endpoint")
-	log.Println("💡 If programs need a specific port, use add_otlp_port to listen on it")
-	log.Println()
+	// 7. Run MCP server on selected transport
+	switch cfg.Transport {
+	case "http":
+		log.Printf("🌐 MCP server starting on http://%s:%d/mcp\n", cfg.HTTPHost, cfg.HTTPPort)
+		log.Println("💡 Use MCP tools to query traces and get the OTLP endpoint")
+		log.Println("💡 If programs need a specific port, use add_otlp_port to listen on it")
+		log.Println()
 
-	if err := mcpServer.Run(ctx); err != nil {
-		// Check if OTLP receiver had an error
-		select {
-		case otlpErr := <-otlpErrChan:
-			if otlpErr != nil {
-				return fmt.Errorf("OTLP receiver error: %w", otlpErr)
-			}
-		default:
+		if err := runHTTPTransport(ctx, cfg, mcpServer, otlpErrChan); err != nil {
+			return err
 		}
 
-		return fmt.Errorf("MCP server error: %w", err)
+	case "stdio", "":
+		log.Println("🎯 MCP server ready on stdio")
+		log.Println("💡 Use MCP tools to query traces and get the OTLP endpoint")
+		log.Println("💡 If programs need a specific port, use add_otlp_port to listen on it")
+		log.Println()
+
+		if err := mcpServer.Run(ctx); err != nil {
+			// Check if OTLP receiver had an error
+			select {
+			case otlpErr := <-otlpErrChan:
+				if otlpErr != nil {
+					return fmt.Errorf("OTLP receiver error: %w", otlpErr)
+				}
+			default:
+			}
+			return fmt.Errorf("MCP server error: %w", err)
+		}
+
+	default:
+		return fmt.Errorf("unknown transport: %s (use 'stdio' or 'http')", cfg.Transport)
 	}
 
 	return nil
+}
+
+// runHTTPTransport starts the MCP server using Streamable HTTP transport.
+// It creates an HTTP server with origin validation and graceful shutdown.
+func runHTTPTransport(ctx context.Context, cfg *Config, mcpServer *mcpserver.Server, otlpErrChan chan error) error {
+	// Parse session timeout
+	sessionTimeout, err := time.ParseDuration(cfg.SessionTimeout)
+	if err != nil {
+		log.Printf("⚠️  Invalid session timeout %q, using default 30m: %v", cfg.SessionTimeout, err)
+		sessionTimeout = 30 * time.Minute
+	}
+
+	// Create StreamableHTTPHandler from SDK
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server {
+			return mcpServer.MCPServer()
+		},
+		&mcp.StreamableHTTPOptions{
+			Stateless:      cfg.Stateless,
+			SessionTimeout: sessionTimeout,
+		},
+	)
+
+	// Wrap with origin validation middleware
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", originValidationMiddleware(cfg.AllowedOrigins, handler))
+	mux.Handle("/mcp/", originValidationMiddleware(cfg.AllowedOrigins, handler))
+
+	// Create HTTP server with proper timeouts
+	server := &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", cfg.HTTPHost, cfg.HTTPPort),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	// Start server in background
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	// Wait for shutdown signal or errors
+	select {
+	case <-ctx.Done():
+		// Graceful shutdown
+		mcpServer.Shutdown()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+
+	case err := <-serverErr:
+		return fmt.Errorf("HTTP server error: %w", err)
+
+	case err := <-otlpErrChan:
+		if err != nil {
+			return fmt.Errorf("OTLP receiver error: %w", err)
+		}
+		return nil
+	}
+}
+
+// originValidationMiddleware validates Origin headers and sets CORS headers.
+// It supports wildcard patterns like "http://localhost:*".
+func originValidationMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+
+		// No Origin header - allow (same-origin or non-browser client)
+		if origin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Check against allowed origins
+		if !isOriginAllowed(origin, allowedOrigins) {
+			http.Error(w, "Origin not allowed", http.StatusForbidden)
+			return
+		}
+
+		// Set CORS headers for allowed origins
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, Last-Event-Id")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+
+		// Handle preflight OPTIONS request
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isOriginAllowed checks if the origin matches any allowed pattern.
+// Supports wildcards: "http://localhost:*" matches "http://localhost:8080".
+func isOriginAllowed(origin string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if matchOriginPattern(origin, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchOriginPattern matches an origin against a pattern with wildcard support.
+// Supports "*" as a wildcard for the port portion only.
+func matchOriginPattern(origin, pattern string) bool {
+	// Exact match
+	if origin == pattern {
+		return true
+	}
+
+	// Wildcard match (e.g., "http://localhost:*")
+	if strings.HasSuffix(pattern, ":*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		if strings.HasPrefix(origin, prefix) {
+			// Verify remaining part is numeric (port)
+			remainder := strings.TrimPrefix(origin, prefix)
+			for _, c := range remainder {
+				if c < '0' || c > '9' {
+					return false
+				}
+			}
+			return len(remainder) > 0
+		}
+	}
+
+	return false
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -105,6 +105,18 @@ func (s *Server) Run(ctx context.Context) error {
 	return err
 }
 
+// MCPServer returns the underlying mcp.Server for use with alternative transports.
+// This enables the server to be used with StreamableHTTPHandler for HTTP transport.
+func (s *Server) MCPServer() *mcp.Server {
+	return s.mcpServer
+}
+
+// Shutdown performs cleanup when using non-stdio transports.
+// For stdio transport, this cleanup is handled by Run() automatically.
+func (s *Server) Shutdown() {
+	s.stopAllFileSources()
+}
+
 // AddFileSource adds a new file source that reads OTLP JSONL from a directory.
 // Returns an error if the directory is already being watched.
 func (s *Server) AddFileSource(ctx context.Context, directory string) error {

--- a/systemd/otlp-mcp.service
+++ b/systemd/otlp-mcp.service
@@ -1,0 +1,58 @@
+# OTLP MCP Server - Systemd User Unit
+#
+# This unit runs otlp-mcp as a persistent HTTP service, auto-discovering
+# file sources from the otel-collector configuration.
+#
+# Installation:
+#   ln -s ~/src/otlp-mcp/systemd/otlp-mcp.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now otlp-mcp
+#
+# Verify:
+#   systemctl --user status otlp-mcp
+#   journalctl --user -u otlp-mcp -f
+#
+# MCP Endpoint:
+#   http://127.0.0.1:4380/mcp
+#
+# Claude Code Configuration (~/.claude.json):
+#   {
+#     "mcpServers": {
+#       "otlp-mcp": {
+#         "type": "streamableHttp",
+#         "url": "http://127.0.0.1:4380/mcp"
+#       }
+#     }
+#   }
+#
+# Customization:
+#   --http-host     Bind address (default: 127.0.0.1)
+#   --http-port     Listen port (default: 4380)
+#   --otel-config   Path to otel-collector config.yaml
+#   --file-source   Manual directory for OTLP JSONL files (can repeat)
+#   --verbose       Enable detailed logging
+#
+# Without --otel-config, the OTLP gRPC receiver starts automatically.
+# With --otel-config, only file sources are used (agent can enable OTLP via tools).
+
+[Unit]
+Description=OTLP MCP Server (HTTP Transport)
+After=network.target otelcol.service
+
+[Service]
+Type=exec
+ExecStart=%h/src/otlp-mcp/otlp-mcp serve \
+    --transport http \
+    --http-host 127.0.0.1 \
+    --http-port 4380 \
+    --otel-config /etc/otelcol/config.yaml
+Restart=on-failure
+RestartSec=10
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=otlp-mcp
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Adds HTTP transport mode and otel-collector config integration to otlp-mcp, enabling it to run as a persistent service with auto-discovery of file sources.

### HTTP Transport
- `--transport http` serves MCP via Streamable HTTP at `/mcp`
- Default port: 4380 (leaves room for future UI at `/`)
- Origin validation middleware with wildcard support

### Otel-Config Integration  
- `--otel-config` parses collector config.yaml to auto-discover file exporter directories
- When set, skips starting the OTLP listener (agent can enable via `add_otlp_port` if needed)
- Perfect for developers who already have otel-collector writing JSONL files

### Systemd Unit
- `systemd/otlp-mcp.service` for running as a user service
- Symlink to `~/.config/systemd/user/` to enable

## Changes

- `internal/cli/config.go`: Added Transport, HTTPHost, HTTPPort, AllowedOrigins, SessionTimeout, Stateless fields
- `internal/cli/serve.go`: Added CLI flags, transport selection, HTTP server lifecycle, origin middleware
- `internal/cli/otelconfig.go`: New YAML parser for otel collector config
- `internal/mcpserver/server.go`: Added MCPServer() getter and Shutdown() method
- `systemd/otlp-mcp.service`: Systemd user unit

## Usage

```bash
# Stdio mode (default, unchanged)
./otlp-mcp serve

# HTTP mode on port 4380
./otlp-mcp serve --transport http

# HTTP mode with otel-collector file sources
./otlp-mcp serve --transport http --otel-config /etc/otelcol/config.yaml

# Systemd setup
ln -s ~/src/otlp-mcp/systemd/otlp-mcp.service ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now otlp-mcp
```

## Test Plan

- [x] All existing tests pass
- [x] HTTP transport starts and binds correctly
- [x] otel-config parses and auto-discovers file sources
- [x] OTLP listener is disabled when using otel-config
- [ ] Manual test with MCP client over HTTP

Co-Authored-By: Claude <claude@anthropic.com>