### PR TITLE
feat: add status and recent_activity tools for fast polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you're helping a user with OpenTelemetry-instrumented code, this MCP server e
 
 ## Status
 
-✅ **Production Ready** - Full implementation complete with 9 snapshot-first MCP tools:
+✅ **Production Ready** - Full implementation complete with 11 MCP tools:
 - **Unified OTLP endpoint** - Single port accepts traces, logs, and metrics
 - **Dynamic port management** - Add/remove listening ports without restart
 - **Snapshot-based temporal queries** - Compare before/after states
@@ -149,7 +149,7 @@ You should get back something like:
 
 ## MCP Tools
 
-The server provides 9 snapshot-first tools for temporal observability:
+The server provides 11 tools for observability:
 
 | Tool | Description |
 |------|-------------|
@@ -162,6 +162,8 @@ The server provides 9 snapshot-first tools for temporal observability:
 | `manage_snapshots` | List/delete/clear snapshots. Surgical cleanup - prefer this over `clear_data` for targeted housekeeping |
 | `get_stats` | Buffer health dashboard - check capacity, current usage, and snapshot count. Use before long-running observations to avoid buffer wraparound |
 | `clear_data` | Nuclear option - wipes ALL telemetry data and snapshots. Use sparingly for complete resets |
+| `status` | Fast status check - monotonic counters, generation for change detection, error count, uptime |
+| `recent_activity` | Recent activity summary - traces (deduplicated), errors, throughput, optional metric peek with histogram percentiles |
 
 ## Workflow Examples
 

--- a/internal/storage/activity_cache.go
+++ b/internal/storage/activity_cache.go
@@ -1,0 +1,406 @@
+package storage
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// ActivityCache provides fast access to telemetry data for frequent polling.
+// All counters use atomic operations for lock-free reads.
+type ActivityCache struct {
+	// Monotonic counters (never reset, wrap at uint64 max)
+	spansReceived   atomic.Uint64
+	logsReceived    atomic.Uint64
+	metricsReceived atomic.Uint64
+
+	// Generation counter for change detection
+	// Incremented on any telemetry receipt
+	generation atomic.Uint64
+
+	// Recent errors ring buffer (separate from main log storage)
+	recentErrors *RingBuffer[*ErrorEntry]
+
+	// Recent traces tracking - deduplicated by service:rootSpan
+	// This keeps one entry per unique service+rootSpan combo, showing the most recent
+	recentTracesMu    sync.RWMutex
+	recentTraces      map[string]*TraceEntry // key: "service:rootSpan"
+	traceIDToKey      map[string]string      // traceID -> "service:rootSpan" for updates
+	traceInsertOrder  []string               // keys in insertion order for LRU eviction
+
+	// Metric peek cache - keyed by metric name
+	metricPeekMu   sync.RWMutex
+	metricPeekData map[string]*MetricPeek
+
+	// Start time for uptime calculation
+	startTime time.Time
+}
+
+// ErrorEntry captures minimal error info for activity tracking.
+type ErrorEntry struct {
+	TraceID   string
+	SpanID    string
+	Service   string
+	SpanName  string
+	ErrorMsg  string
+	Timestamp uint64 // Unix nano
+}
+
+// TraceEntry captures trace-level info for activity tracking.
+type TraceEntry struct {
+	TraceID    string
+	Service    string
+	RootSpan   string
+	Status     string // OK, ERROR, UNSET
+	DurationMs float64
+	ErrorMsg   string // If failed
+	Timestamp  uint64 // Start time
+	SpanCount  int
+	HasRoot    bool // True if we've seen the actual root span
+}
+
+// MetricPeek holds the current value(s) of a metric for quick access.
+type MetricPeek struct {
+	Name        string
+	Type        MetricType
+	LastUpdated uint64
+
+	// For Gauge/Sum
+	Value *float64
+
+	// For Histogram
+	Count       *uint64
+	Sum         *float64
+	Min         *float64
+	Max         *float64
+	Percentiles map[string]float64 // p50, p95, p99
+}
+
+const (
+	// DefaultRecentErrorsCapacity is the number of recent errors to track.
+	DefaultRecentErrorsCapacity = 100
+
+	// DefaultRecentTracesCapacity is the number of recent traces to track.
+	DefaultRecentTracesCapacity = 50
+)
+
+// NewActivityCache creates a new activity cache.
+func NewActivityCache() *ActivityCache {
+	return &ActivityCache{
+		recentErrors:     NewRingBuffer[*ErrorEntry](DefaultRecentErrorsCapacity),
+		recentTraces:     make(map[string]*TraceEntry),
+		traceIDToKey:     make(map[string]string),
+		traceInsertOrder: make([]string, 0, DefaultRecentTracesCapacity),
+		metricPeekData:   make(map[string]*MetricPeek),
+		startTime:        time.Now(),
+	}
+}
+
+// RecordSpan records a span for activity tracking.
+// Called from ObservabilityStorage when spans are received.
+func (h *ActivityCache) RecordSpan(span *StoredSpan) {
+	h.spansReceived.Add(1)
+	h.generation.Add(1)
+
+	// Check for errors
+	if span.Span.Status != nil && span.Span.Status.Code == tracepb.Status_STATUS_CODE_ERROR {
+		errorMsg := span.Span.Status.Message
+		h.recentErrors.Add(&ErrorEntry{
+			TraceID:   span.TraceID,
+			SpanID:    span.SpanID,
+			Service:   span.ServiceName,
+			SpanName:  span.SpanName,
+			ErrorMsg:  errorMsg,
+			Timestamp: span.Span.StartTimeUnixNano,
+		})
+	}
+
+	// Track trace-level info
+	h.updateTraceEntry(span)
+}
+
+// updateTraceEntry updates or creates a trace entry.
+// Deduplicates by service:rootSpan - if we see a new trace with the same
+// service and root span name, we replace the old entry with the new one.
+func (h *ActivityCache) updateTraceEntry(span *StoredSpan) {
+	h.recentTracesMu.Lock()
+	defer h.recentTracesMu.Unlock()
+
+	traceID := span.TraceID
+	isRoot := len(span.Span.ParentSpanId) == 0
+
+	// Calculate status
+	status := "UNSET"
+	var errorMsg string
+	if span.Span.Status != nil {
+		switch span.Span.Status.Code {
+		case tracepb.Status_STATUS_CODE_OK:
+			status = "OK"
+		case tracepb.Status_STATUS_CODE_ERROR:
+			status = "ERROR"
+			errorMsg = span.Span.Status.Message
+		}
+	}
+
+	// Calculate duration
+	durationNs := span.Span.EndTimeUnixNano - span.Span.StartTimeUnixNano
+	durationMs := float64(durationNs) / 1_000_000.0
+
+	// Check if this trace ID already has an entry (continuing an existing trace)
+	if existingKey, exists := h.traceIDToKey[traceID]; exists {
+		if entry, ok := h.recentTraces[existingKey]; ok {
+			entry.SpanCount++
+			// Update to root span if this is one and we haven't seen root yet
+			if isRoot && !entry.HasRoot {
+				// Received root span - re-key entry from child span name to root span name
+				newKey := span.ServiceName + ":" + span.SpanName
+				if newKey != existingKey {
+					// Move entry to new key
+					delete(h.recentTraces, existingKey)
+					h.recentTraces[newKey] = entry
+					h.traceIDToKey[traceID] = newKey
+					// Update insert order
+					h.updateInsertOrder(existingKey, newKey)
+				}
+				entry.RootSpan = span.SpanName
+				entry.HasRoot = true
+				entry.DurationMs = durationMs
+				entry.Timestamp = span.Span.StartTimeUnixNano
+			}
+			// Propagate error status
+			if status == "ERROR" {
+				entry.Status = "ERROR"
+				entry.ErrorMsg = errorMsg
+			}
+			return
+		}
+	}
+
+	// New trace - create entry
+	spanName := span.SpanName
+	key := span.ServiceName + ":" + spanName
+
+	// Check if we already have an entry with this service:spanName
+	// If so, replace it (this is the deduplication)
+	if existingEntry, exists := h.recentTraces[key]; exists {
+		// Remove old trace ID mapping
+		delete(h.traceIDToKey, existingEntry.TraceID)
+	}
+
+	entry := &TraceEntry{
+		TraceID:    traceID,
+		Service:    span.ServiceName,
+		RootSpan:   spanName,
+		Status:     status,
+		DurationMs: durationMs,
+		ErrorMsg:   errorMsg,
+		Timestamp:  span.Span.StartTimeUnixNano,
+		SpanCount:  1,
+		HasRoot:    isRoot,
+	}
+
+	h.recentTraces[key] = entry
+	h.traceIDToKey[traceID] = key
+
+	// Update insert order (move to end if exists, add if new)
+	h.updateInsertOrder("", key)
+
+	// Evict oldest if over capacity
+	h.evictOldestTraces()
+}
+
+// updateInsertOrder updates the insertion order tracking.
+// If oldKey is non-empty, removes it. Adds newKey to the end.
+func (h *ActivityCache) updateInsertOrder(oldKey, newKey string) {
+	// Remove old key if present
+	if oldKey != "" {
+		for i, k := range h.traceInsertOrder {
+			if k == oldKey {
+				h.traceInsertOrder = append(h.traceInsertOrder[:i], h.traceInsertOrder[i+1:]...)
+				break
+			}
+		}
+	}
+
+	// Remove newKey if it exists (we'll re-add at end)
+	for i, k := range h.traceInsertOrder {
+		if k == newKey {
+			h.traceInsertOrder = append(h.traceInsertOrder[:i], h.traceInsertOrder[i+1:]...)
+			break
+		}
+	}
+
+	// Add to end
+	h.traceInsertOrder = append(h.traceInsertOrder, newKey)
+}
+
+// evictOldestTraces removes oldest entries if over capacity.
+func (h *ActivityCache) evictOldestTraces() {
+	for len(h.traceInsertOrder) > DefaultRecentTracesCapacity {
+		oldestKey := h.traceInsertOrder[0]
+		h.traceInsertOrder = h.traceInsertOrder[1:]
+
+		if entry, exists := h.recentTraces[oldestKey]; exists {
+			delete(h.traceIDToKey, entry.TraceID)
+			delete(h.recentTraces, oldestKey)
+		}
+	}
+}
+
+// RecordLog records a log entry for activity tracking.
+func (h *ActivityCache) RecordLog() {
+	h.logsReceived.Add(1)
+	h.generation.Add(1)
+}
+
+// RecordMetric records a metric for activity tracking.
+func (h *ActivityCache) RecordMetric(stored *StoredMetric) {
+	h.metricsReceived.Add(1)
+	h.generation.Add(1)
+
+	// Update metric peek cache
+	h.updateMetricPeek(stored)
+}
+
+// updateMetricPeek updates the peek cache for a metric.
+func (h *ActivityCache) updateMetricPeek(stored *StoredMetric) {
+	h.metricPeekMu.Lock()
+	defer h.metricPeekMu.Unlock()
+
+	peek := &MetricPeek{
+		Name:        stored.MetricName,
+		Type:        stored.MetricType,
+		LastUpdated: stored.Timestamp,
+		Value:       stored.NumericValue,
+		Count:       stored.Count,
+		Sum:         stored.Sum,
+	}
+
+	// Extract histogram percentiles if available
+	if stored.MetricType == MetricTypeHistogram {
+		if hist, ok := stored.Metric.Data.(*metricspb.Metric_Histogram); ok {
+			if len(hist.Histogram.DataPoints) > 0 {
+				dp := hist.Histogram.DataPoints[0]
+				peek.Min = dp.Min
+				peek.Max = dp.Max
+				peek.Percentiles = ComputeHistogramPercentiles(dp)
+			}
+		}
+	}
+
+	h.metricPeekData[stored.MetricName] = peek
+}
+
+// SpansReceived returns the total number of spans received.
+func (h *ActivityCache) SpansReceived() uint64 {
+	return h.spansReceived.Load()
+}
+
+// LogsReceived returns the total number of logs received.
+func (h *ActivityCache) LogsReceived() uint64 {
+	return h.logsReceived.Load()
+}
+
+// MetricsReceived returns the total number of metrics received.
+func (h *ActivityCache) MetricsReceived() uint64 {
+	return h.metricsReceived.Load()
+}
+
+// Generation returns the current generation counter.
+func (h *ActivityCache) Generation() uint64 {
+	return h.generation.Load()
+}
+
+// RecentErrorCount returns the number of recent errors tracked.
+func (h *ActivityCache) RecentErrorCount() int {
+	return h.recentErrors.Size()
+}
+
+// UptimeSeconds returns the uptime in seconds.
+func (h *ActivityCache) UptimeSeconds() float64 {
+	return time.Since(h.startTime).Seconds()
+}
+
+// RecentErrors returns the N most recent errors.
+func (h *ActivityCache) RecentErrors(n int) []*ErrorEntry {
+	return h.recentErrors.GetRecent(n)
+}
+
+// RecentTraces returns the N most recent traces.
+func (h *ActivityCache) RecentTraces(n int) []*TraceEntry {
+	h.recentTracesMu.RLock()
+	defer h.recentTracesMu.RUnlock()
+
+	// Return the most recent n entries (from the end of insert order)
+	count := len(h.traceInsertOrder)
+	if n > count {
+		n = count
+	}
+	if n == 0 {
+		return nil
+	}
+
+	result := make([]*TraceEntry, n)
+	for i := 0; i < n; i++ {
+		key := h.traceInsertOrder[count-n+i]
+		if entry, exists := h.recentTraces[key]; exists {
+			// Return a copy to avoid data races
+			entryCopy := *entry
+			result[i] = &entryCopy
+		}
+	}
+
+	return result
+}
+
+// PeekMetrics returns the current values for the specified metric names.
+// Returns only metrics that exist in the cache. Limit to MaxMetricPeek names.
+func (h *ActivityCache) PeekMetrics(names []string) []*MetricPeek {
+	if len(names) == 0 {
+		return nil
+	}
+
+	h.metricPeekMu.RLock()
+	defer h.metricPeekMu.RUnlock()
+
+	result := make([]*MetricPeek, 0, len(names))
+	for _, name := range names {
+		if peek, exists := h.metricPeekData[name]; exists {
+			// Return a copy to avoid data races
+			peekCopy := *peek
+			if peek.Percentiles != nil {
+				peekCopy.Percentiles = make(map[string]float64, len(peek.Percentiles))
+				for k, v := range peek.Percentiles {
+					peekCopy.Percentiles[k] = v
+				}
+			}
+			result = append(result, &peekCopy)
+		}
+	}
+
+	return result
+}
+
+// Clear resets all activity cache data.
+func (h *ActivityCache) Clear() {
+	h.spansReceived.Store(0)
+	h.logsReceived.Store(0)
+	h.metricsReceived.Store(0)
+	h.generation.Store(0)
+	h.recentErrors.Clear()
+
+	h.recentTracesMu.Lock()
+	h.recentTraces = make(map[string]*TraceEntry)
+	h.traceIDToKey = make(map[string]string)
+	h.traceInsertOrder = make([]string, 0, DefaultRecentTracesCapacity)
+	h.recentTracesMu.Unlock()
+
+	h.metricPeekMu.Lock()
+	h.metricPeekData = make(map[string]*MetricPeek)
+	h.metricPeekMu.Unlock()
+
+	h.startTime = time.Now()
+}

--- a/internal/storage/activity_cache_test.go
+++ b/internal/storage/activity_cache_test.go
@@ -1,0 +1,346 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func TestNewActivityCache(t *testing.T) {
+	cache := NewActivityCache()
+
+	if cache == nil {
+		t.Fatal("NewActivityCache returned nil")
+	}
+
+	// Check initial values
+	if cache.SpansReceived() != 0 {
+		t.Errorf("expected 0 spans received, got %d", cache.SpansReceived())
+	}
+	if cache.LogsReceived() != 0 {
+		t.Errorf("expected 0 logs received, got %d", cache.LogsReceived())
+	}
+	if cache.MetricsReceived() != 0 {
+		t.Errorf("expected 0 metrics received, got %d", cache.MetricsReceived())
+	}
+	if cache.Generation() != 0 {
+		t.Errorf("expected generation 0, got %d", cache.Generation())
+	}
+	if cache.RecentErrorCount() != 0 {
+		t.Errorf("expected 0 recent errors, got %d", cache.RecentErrorCount())
+	}
+}
+
+func TestActivityCacheRecordSpan(t *testing.T) {
+	cache := NewActivityCache()
+
+	// Create a test span
+	span := &StoredSpan{
+		TraceID:     "abc123",
+		SpanID:      "def456",
+		ServiceName: "test-service",
+		SpanName:    "test-span",
+		Span: &tracepb.Span{
+			StartTimeUnixNano: 1000000000,
+			EndTimeUnixNano:   2000000000,
+			Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+		},
+	}
+
+	cache.RecordSpan(span)
+
+	if cache.SpansReceived() != 1 {
+		t.Errorf("expected 1 span received, got %d", cache.SpansReceived())
+	}
+	if cache.Generation() != 1 {
+		t.Errorf("expected generation 1, got %d", cache.Generation())
+	}
+
+	// Check recent traces
+	traces := cache.RecentTraces(5)
+	if len(traces) != 1 {
+		t.Errorf("expected 1 recent trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "abc123" {
+		t.Errorf("expected trace ID abc123, got %s", traces[0].TraceID)
+	}
+	if traces[0].Status != "OK" {
+		t.Errorf("expected status OK, got %s", traces[0].Status)
+	}
+}
+
+func TestActivityCacheRecordSpanWithError(t *testing.T) {
+	cache := NewActivityCache()
+
+	// Create an error span
+	span := &StoredSpan{
+		TraceID:     "error123",
+		SpanID:      "span456",
+		ServiceName: "test-service",
+		SpanName:    "failing-span",
+		Span: &tracepb.Span{
+			StartTimeUnixNano: 1000000000,
+			EndTimeUnixNano:   2000000000,
+			Status: &tracepb.Status{
+				Code:    tracepb.Status_STATUS_CODE_ERROR,
+				Message: "connection refused",
+			},
+		},
+	}
+
+	cache.RecordSpan(span)
+
+	if cache.RecentErrorCount() != 1 {
+		t.Errorf("expected 1 recent error, got %d", cache.RecentErrorCount())
+	}
+
+	errors := cache.RecentErrors(5)
+	if len(errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(errors))
+	}
+	if errors[0].ErrorMsg != "connection refused" {
+		t.Errorf("expected error message 'connection refused', got %s", errors[0].ErrorMsg)
+	}
+
+	// Check that trace entry also shows error
+	traces := cache.RecentTraces(5)
+	if len(traces) != 1 {
+		t.Errorf("expected 1 trace, got %d", len(traces))
+	}
+	if traces[0].Status != "ERROR" {
+		t.Errorf("expected trace status ERROR, got %s", traces[0].Status)
+	}
+}
+
+func TestActivityCacheRecordLog(t *testing.T) {
+	cache := NewActivityCache()
+
+	cache.RecordLog()
+	cache.RecordLog()
+	cache.RecordLog()
+
+	if cache.LogsReceived() != 3 {
+		t.Errorf("expected 3 logs received, got %d", cache.LogsReceived())
+	}
+	if cache.Generation() != 3 {
+		t.Errorf("expected generation 3, got %d", cache.Generation())
+	}
+}
+
+func TestActivityCacheRecordMetric(t *testing.T) {
+	cache := NewActivityCache()
+
+	value := 42.5
+	metric := &StoredMetric{
+		MetricName:   "test.metric",
+		ServiceName:  "test-service",
+		MetricType:   MetricTypeGauge,
+		Timestamp:    1000000000,
+		NumericValue: &value,
+	}
+
+	cache.RecordMetric(metric)
+
+	if cache.MetricsReceived() != 1 {
+		t.Errorf("expected 1 metric received, got %d", cache.MetricsReceived())
+	}
+
+	// Check metric peek
+	peeked := cache.PeekMetrics([]string{"test.metric"})
+	if len(peeked) != 1 {
+		t.Errorf("expected 1 peeked metric, got %d", len(peeked))
+	}
+	if *peeked[0].Value != 42.5 {
+		t.Errorf("expected value 42.5, got %f", *peeked[0].Value)
+	}
+}
+
+func TestActivityCachePeekMetricsNotFound(t *testing.T) {
+	cache := NewActivityCache()
+
+	peeked := cache.PeekMetrics([]string{"nonexistent.metric"})
+	if len(peeked) != 0 {
+		t.Errorf("expected 0 peeked metrics for nonexistent, got %d", len(peeked))
+	}
+}
+
+func TestActivityCacheClear(t *testing.T) {
+	cache := NewActivityCache()
+
+	// Add some data
+	span := &StoredSpan{
+		TraceID:     "abc123",
+		SpanID:      "def456",
+		ServiceName: "test-service",
+		SpanName:    "test-span",
+		Span: &tracepb.Span{
+			StartTimeUnixNano: 1000000000,
+			EndTimeUnixNano:   2000000000,
+			Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+		},
+	}
+	cache.RecordSpan(span)
+	cache.RecordLog()
+
+	value := 42.5
+	metric := &StoredMetric{
+		MetricName:   "test.metric",
+		ServiceName:  "test-service",
+		MetricType:   MetricTypeGauge,
+		NumericValue: &value,
+	}
+	cache.RecordMetric(metric)
+
+	// Clear
+	cache.Clear()
+
+	// Verify everything is reset
+	if cache.SpansReceived() != 0 {
+		t.Errorf("expected 0 spans after clear, got %d", cache.SpansReceived())
+	}
+	if cache.LogsReceived() != 0 {
+		t.Errorf("expected 0 logs after clear, got %d", cache.LogsReceived())
+	}
+	if cache.MetricsReceived() != 0 {
+		t.Errorf("expected 0 metrics after clear, got %d", cache.MetricsReceived())
+	}
+	if cache.Generation() != 0 {
+		t.Errorf("expected generation 0 after clear, got %d", cache.Generation())
+	}
+	if len(cache.RecentTraces(5)) != 0 {
+		t.Errorf("expected 0 traces after clear, got %d", len(cache.RecentTraces(5)))
+	}
+	if len(cache.PeekMetrics([]string{"test.metric"})) != 0 {
+		t.Errorf("expected 0 peeked metrics after clear")
+	}
+}
+
+func TestActivityCacheUptime(t *testing.T) {
+	cache := NewActivityCache()
+
+	// Sleep a tiny bit
+	time.Sleep(10 * time.Millisecond)
+
+	uptime := cache.UptimeSeconds()
+	if uptime < 0.01 {
+		t.Errorf("expected uptime > 0.01s, got %f", uptime)
+	}
+}
+
+func TestActivityCacheTraceUpdate(t *testing.T) {
+	cache := NewActivityCache()
+
+	// First span (not root)
+	span1 := &StoredSpan{
+		TraceID:     "trace123",
+		SpanID:      "span1",
+		ServiceName: "test-service",
+		SpanName:    "child-span",
+		Span: &tracepb.Span{
+			ParentSpanId:      []byte{1, 2, 3, 4, 5, 6, 7, 8},
+			StartTimeUnixNano: 1000000000,
+			EndTimeUnixNano:   1500000000,
+			Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+		},
+	}
+	cache.RecordSpan(span1)
+
+	// Root span (no parent)
+	span2 := &StoredSpan{
+		TraceID:     "trace123",
+		SpanID:      "span2",
+		ServiceName: "test-service",
+		SpanName:    "root-span",
+		Span: &tracepb.Span{
+			ParentSpanId:      nil, // Root span
+			StartTimeUnixNano: 900000000,
+			EndTimeUnixNano:   2000000000,
+			Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+		},
+	}
+	cache.RecordSpan(span2)
+
+	if cache.SpansReceived() != 2 {
+		t.Errorf("expected 2 spans received, got %d", cache.SpansReceived())
+	}
+
+	// Should still be 1 trace entry (updated)
+	traces := cache.RecentTraces(5)
+	if len(traces) != 1 {
+		t.Errorf("expected 1 trace entry, got %d", len(traces))
+	}
+
+	// Root span should now be the "RootSpan"
+	if traces[0].RootSpan != "root-span" {
+		t.Errorf("expected RootSpan 'root-span', got '%s'", traces[0].RootSpan)
+	}
+	if traces[0].SpanCount != 2 {
+		t.Errorf("expected SpanCount 2, got %d", traces[0].SpanCount)
+	}
+}
+
+func TestActivityCacheConcurrency(t *testing.T) {
+	cache := NewActivityCache()
+
+	// Concurrent writes
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			span := &StoredSpan{
+				TraceID:     fmt.Sprintf("trace%d", i),
+				SpanID:      fmt.Sprintf("span%d", i),
+				ServiceName: "test-service",
+				SpanName:    "test-span",
+				Span: &tracepb.Span{
+					StartTimeUnixNano: 1000000000,
+					EndTimeUnixNano:   2000000000,
+					Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+				},
+			}
+			cache.RecordSpan(span)
+			cache.RecordLog()
+
+			value := float64(i)
+			metric := &StoredMetric{
+				MetricName:   "test.metric",
+				ServiceName:  "test-service",
+				MetricType:   MetricTypeGauge,
+				NumericValue: &value,
+			}
+			cache.RecordMetric(metric)
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrent reads
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cache.SpansReceived()
+			_ = cache.LogsReceived()
+			_ = cache.MetricsReceived()
+			_ = cache.Generation()
+			_ = cache.RecentTraces(5)
+			_ = cache.RecentErrors(5)
+			_ = cache.PeekMetrics([]string{"test.metric"})
+		}()
+	}
+	wg.Wait()
+
+	// Verify counts
+	if cache.SpansReceived() != 100 {
+		t.Errorf("expected 100 spans, got %d", cache.SpansReceived())
+	}
+	if cache.LogsReceived() != 100 {
+		t.Errorf("expected 100 logs, got %d", cache.LogsReceived())
+	}
+	if cache.MetricsReceived() != 100 {
+		t.Errorf("expected 100 metrics, got %d", cache.MetricsReceived())
+	}
+}

--- a/internal/storage/histogram_utils.go
+++ b/internal/storage/histogram_utils.go
@@ -1,0 +1,205 @@
+package storage
+
+import (
+	"math"
+
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+// ComputeHistogramPercentiles estimates percentiles from OTLP histogram bucket data.
+// Uses linear interpolation within buckets (standard approach used by Prometheus).
+// Returns nil if bucket data is not available or the histogram is empty.
+func ComputeHistogramPercentiles(dp *metricspb.HistogramDataPoint) map[string]float64 {
+	if dp == nil {
+		return nil
+	}
+
+	bounds := dp.GetExplicitBounds()
+	counts := dp.GetBucketCounts()
+	total := dp.GetCount()
+
+	// Need at least one bucket and non-zero count
+	if len(counts) == 0 || total == 0 {
+		return nil
+	}
+
+	// Compute percentiles
+	percentiles := make(map[string]float64, 3)
+	targets := map[string]float64{"p50": 0.50, "p95": 0.95, "p99": 0.99}
+
+	for name, target := range targets {
+		if p := estimatePercentile(bounds, counts, total, target); !math.IsNaN(p) {
+			percentiles[name] = p
+		}
+	}
+
+	if len(percentiles) == 0 {
+		return nil
+	}
+
+	return percentiles
+}
+
+// estimatePercentile uses linear interpolation within buckets to estimate a percentile.
+// This is the standard histogram_quantile approach used by Prometheus.
+//
+// Bucket layout in OTLP:
+//   - counts[i] is the count for bucket i
+//   - bounds[i] is the upper bound of bucket i (exclusive)
+//   - bucket 0: (-Inf, bounds[0]]
+//   - bucket i: (bounds[i-1], bounds[i]]
+//   - bucket n: (bounds[n-1], +Inf)  (the overflow bucket)
+//
+// For n bounds, there are n+1 buckets.
+func estimatePercentile(bounds []float64, counts []uint64, total uint64, target float64) float64 {
+	targetCount := float64(total) * target
+	cumulative := uint64(0)
+
+	for i, count := range counts {
+		cumulative += count
+
+		if float64(cumulative) >= targetCount && count > 0 {
+			// Found the bucket containing the percentile
+			var lowerBound, upperBound float64
+
+			// Determine bucket bounds
+			if i == 0 {
+				// First bucket: (-Inf, bounds[0]]
+				// Use 0 as lower bound (common heuristic for latencies)
+				lowerBound = 0
+				if len(bounds) > 0 {
+					upperBound = bounds[0]
+				} else {
+					// No bounds at all, can't interpolate
+					return math.NaN()
+				}
+			} else if i < len(bounds) {
+				// Middle bucket: (bounds[i-1], bounds[i]]
+				lowerBound = bounds[i-1]
+				upperBound = bounds[i]
+			} else {
+				// Overflow bucket: (bounds[n-1], +Inf)
+				// Can't interpolate into infinity, return the last bound
+				if len(bounds) > 0 {
+					return bounds[len(bounds)-1]
+				}
+				return math.NaN()
+			}
+
+			// Linear interpolation within the bucket
+			prevCumulative := cumulative - count
+			fraction := (targetCount - float64(prevCumulative)) / float64(count)
+
+			return lowerBound + fraction*(upperBound-lowerBound)
+		}
+	}
+
+	// Should not reach here if total > 0 and target <= 1.0
+	// Return the last bound as fallback
+	if len(bounds) > 0 {
+		return bounds[len(bounds)-1]
+	}
+	return math.NaN()
+}
+
+// ComputeExponentialHistogramPercentiles estimates percentiles from exponential histogram data.
+// Exponential histograms use a base and scale to define bucket boundaries.
+// Returns nil if the histogram is empty or has no buckets.
+func ComputeExponentialHistogramPercentiles(dp *metricspb.ExponentialHistogramDataPoint) map[string]float64 {
+	if dp == nil || dp.Count == 0 {
+		return nil
+	}
+
+	// Exponential histogram bucket boundaries:
+	// base = 2^(2^(-scale))
+	// bucket[i] = base^i
+	scale := dp.Scale
+	base := math.Pow(2, math.Pow(2, float64(-scale)))
+
+	// Collect all bucket counts with their boundaries
+	type bucket struct {
+		lower, upper float64
+		count        uint64
+	}
+	var buckets []bucket
+
+	// Zero bucket (if present)
+	if dp.ZeroCount > 0 {
+		// Zero bucket covers [-zeroThreshold, +zeroThreshold]
+		threshold := dp.ZeroThreshold
+		if threshold == 0 {
+			threshold = math.SmallestNonzeroFloat64
+		}
+		buckets = append(buckets, bucket{-threshold, threshold, dp.ZeroCount})
+	}
+
+	// Negative buckets (from most negative to zero)
+	if dp.Negative != nil {
+		offset := dp.Negative.Offset
+		for i, count := range dp.Negative.BucketCounts {
+			if count > 0 {
+				idx := offset + int32(i)
+				upper := -math.Pow(base, float64(idx))
+				lower := -math.Pow(base, float64(idx+1))
+				buckets = append(buckets, bucket{lower, upper, count})
+			}
+		}
+	}
+
+	// Positive buckets (from zero to most positive)
+	if dp.Positive != nil {
+		offset := dp.Positive.Offset
+		for i, count := range dp.Positive.BucketCounts {
+			if count > 0 {
+				idx := offset + int32(i)
+				lower := math.Pow(base, float64(idx))
+				upper := math.Pow(base, float64(idx+1))
+				buckets = append(buckets, bucket{lower, upper, count})
+			}
+		}
+	}
+
+	if len(buckets) == 0 {
+		return nil
+	}
+
+	// Sort buckets by lower bound (they should already be sorted, but be safe)
+	// Using simple bubble sort since we expect few buckets
+	for i := 0; i < len(buckets); i++ {
+		for j := i + 1; j < len(buckets); j++ {
+			if buckets[i].lower > buckets[j].lower {
+				buckets[i], buckets[j] = buckets[j], buckets[i]
+			}
+		}
+	}
+
+	// Compute percentiles using the same interpolation logic
+	percentiles := make(map[string]float64, 3)
+	targets := map[string]float64{"p50": 0.50, "p95": 0.95, "p99": 0.99}
+
+	total := dp.Count
+	for name, target := range targets {
+		targetCount := float64(total) * target
+		cumulative := uint64(0)
+
+		for _, b := range buckets {
+			cumulative += b.count
+
+			if float64(cumulative) >= targetCount && b.count > 0 {
+				prevCumulative := cumulative - b.count
+				fraction := (targetCount - float64(prevCumulative)) / float64(b.count)
+				p := b.lower + fraction*(b.upper-b.lower)
+				if !math.IsNaN(p) && !math.IsInf(p, 0) {
+					percentiles[name] = p
+				}
+				break
+			}
+		}
+	}
+
+	if len(percentiles) == 0 {
+		return nil
+	}
+
+	return percentiles
+}

--- a/internal/storage/histogram_utils_test.go
+++ b/internal/storage/histogram_utils_test.go
@@ -1,0 +1,254 @@
+package storage
+
+import (
+	"math"
+	"testing"
+
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+func TestComputeHistogramPercentiles(t *testing.T) {
+	tests := []struct {
+		name           string
+		dataPoint      *metricspb.HistogramDataPoint
+		expectNil      bool
+		expectP50Range [2]float64 // [min, max] expected range
+		expectP95Range [2]float64
+		expectP99Range [2]float64
+	}{
+		{
+			name:      "nil data point",
+			dataPoint: nil,
+			expectNil: true,
+		},
+		{
+			name: "empty counts",
+			dataPoint: &metricspb.HistogramDataPoint{
+				Count:          0,
+				ExplicitBounds: []float64{10, 50, 100},
+				BucketCounts:   []uint64{},
+			},
+			expectNil: true,
+		},
+		{
+			name: "zero total count",
+			dataPoint: &metricspb.HistogramDataPoint{
+				Count:          0,
+				ExplicitBounds: []float64{10, 50, 100},
+				BucketCounts:   []uint64{0, 0, 0, 0},
+			},
+			expectNil: true,
+		},
+		{
+			name: "simple histogram - all in first bucket",
+			dataPoint: &metricspb.HistogramDataPoint{
+				Count:          100,
+				ExplicitBounds: []float64{10, 50, 100},
+				BucketCounts:   []uint64{100, 0, 0, 0}, // All values <= 10
+			},
+			expectNil:      false,
+			expectP50Range: [2]float64{0, 10},
+			expectP95Range: [2]float64{0, 10},
+			expectP99Range: [2]float64{0, 10},
+		},
+		{
+			name: "uniform distribution",
+			dataPoint: &metricspb.HistogramDataPoint{
+				Count:          100,
+				ExplicitBounds: []float64{25, 50, 75, 100},
+				BucketCounts:   []uint64{25, 25, 25, 25, 0}, // Even distribution
+			},
+			expectNil:      false,
+			expectP50Range: [2]float64{25, 75}, // Should be around 50
+			expectP95Range: [2]float64{75, 100},
+			expectP99Range: [2]float64{75, 100},
+		},
+		{
+			name: "realistic latency histogram",
+			dataPoint: &metricspb.HistogramDataPoint{
+				Count:          1000,
+				ExplicitBounds: []float64{5, 10, 25, 50, 100, 250, 500, 1000}, // ms buckets
+				BucketCounts:   []uint64{100, 300, 400, 150, 30, 15, 4, 1, 0},
+			},
+			expectNil:      false,
+			expectP50Range: [2]float64{10, 25},  // Most values in 10-25ms bucket
+			expectP95Range: [2]float64{50, 250}, // 95th percentile in higher buckets
+			expectP99Range: [2]float64{100, 1000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ComputeHistogramPercentiles(tt.dataPoint)
+
+			if tt.expectNil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			// Check p50
+			if p50, ok := result["p50"]; ok {
+				if p50 < tt.expectP50Range[0] || p50 > tt.expectP50Range[1] {
+					t.Errorf("p50 = %f, expected in range [%f, %f]", p50, tt.expectP50Range[0], tt.expectP50Range[1])
+				}
+			} else {
+				t.Error("missing p50")
+			}
+
+			// Check p95
+			if p95, ok := result["p95"]; ok {
+				if p95 < tt.expectP95Range[0] || p95 > tt.expectP95Range[1] {
+					t.Errorf("p95 = %f, expected in range [%f, %f]", p95, tt.expectP95Range[0], tt.expectP95Range[1])
+				}
+			} else {
+				t.Error("missing p95")
+			}
+
+			// Check p99
+			if p99, ok := result["p99"]; ok {
+				if p99 < tt.expectP99Range[0] || p99 > tt.expectP99Range[1] {
+					t.Errorf("p99 = %f, expected in range [%f, %f]", p99, tt.expectP99Range[0], tt.expectP99Range[1])
+				}
+			} else {
+				t.Error("missing p99")
+			}
+		})
+	}
+}
+
+func TestEstimatePercentileLinearInterpolation(t *testing.T) {
+	// Test linear interpolation within a bucket
+	bounds := []float64{100}
+	counts := []uint64{100} // All 100 values in [0, 100]
+	total := uint64(100)
+
+	// p50 should be around 50 (linear interpolation)
+	p50 := estimatePercentile(bounds, counts, total, 0.50)
+	if math.Abs(p50-50) > 1 {
+		t.Errorf("p50 = %f, expected ~50", p50)
+	}
+
+	// p90 should be around 90
+	p90 := estimatePercentile(bounds, counts, total, 0.90)
+	if math.Abs(p90-90) > 1 {
+		t.Errorf("p90 = %f, expected ~90", p90)
+	}
+}
+
+func TestComputeExponentialHistogramPercentiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataPoint *metricspb.ExponentialHistogramDataPoint
+		expectNil bool
+	}{
+		{
+			name:      "nil data point",
+			dataPoint: nil,
+			expectNil: true,
+		},
+		{
+			name: "zero count",
+			dataPoint: &metricspb.ExponentialHistogramDataPoint{
+				Count: 0,
+			},
+			expectNil: true,
+		},
+		{
+			name: "only zero bucket",
+			dataPoint: &metricspb.ExponentialHistogramDataPoint{
+				Count:         100,
+				ZeroCount:     100,
+				ZeroThreshold: 0.001,
+				Scale:         2,
+			},
+			expectNil: false,
+		},
+		{
+			name: "positive buckets",
+			dataPoint: &metricspb.ExponentialHistogramDataPoint{
+				Count: 100,
+				Scale: 2,
+				Positive: &metricspb.ExponentialHistogramDataPoint_Buckets{
+					Offset:       0,
+					BucketCounts: []uint64{25, 25, 25, 25},
+				},
+			},
+			expectNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ComputeExponentialHistogramPercentiles(tt.dataPoint)
+
+			if tt.expectNil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			// Just verify we got the expected keys
+			for _, key := range []string{"p50", "p95", "p99"} {
+				if _, ok := result[key]; !ok {
+					t.Errorf("missing %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestPercentileOrderingProperty(t *testing.T) {
+	// Property: p50 <= p95 <= p99 should always hold
+	dataPoint := &metricspb.HistogramDataPoint{
+		Count:          1000,
+		ExplicitBounds: []float64{10, 25, 50, 100, 250, 500},
+		BucketCounts:   []uint64{100, 200, 400, 200, 80, 15, 5},
+	}
+
+	result := ComputeHistogramPercentiles(dataPoint)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	p50 := result["p50"]
+	p95 := result["p95"]
+	p99 := result["p99"]
+
+	if p50 > p95 {
+		t.Errorf("p50 (%f) > p95 (%f), should be <=", p50, p95)
+	}
+	if p95 > p99 {
+		t.Errorf("p95 (%f) > p99 (%f), should be <=", p95, p99)
+	}
+}
+
+func TestOverflowBucket(t *testing.T) {
+	// Test behavior when percentile falls in overflow bucket
+	dataPoint := &metricspb.HistogramDataPoint{
+		Count:          100,
+		ExplicitBounds: []float64{10, 50},
+		BucketCounts:   []uint64{5, 5, 90}, // 90% in overflow bucket (>50)
+	}
+
+	result := ComputeHistogramPercentiles(dataPoint)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// p99 should be at the last bound since we can't interpolate into infinity
+	p99 := result["p99"]
+	if p99 < 50 {
+		t.Errorf("p99 = %f, expected >= 50 (last bound)", p99)
+	}
+}

--- a/internal/storage/metric_storage.go
+++ b/internal/storage/metric_storage.go
@@ -92,6 +92,11 @@ func (ms *MetricStorage) ReceiveMetrics(ctx context.Context, resourceMetrics []*
 	return nil
 }
 
+// addMetric adds a single metric to storage.
+func (ms *MetricStorage) addMetric(metric *StoredMetric) {
+	ms.metrics.Add(metric)
+}
+
 // GetRecentMetrics returns the N most recent metrics.
 func (ms *MetricStorage) GetRecentMetrics(n int) []*StoredMetric {
 	return ms.metrics.GetRecent(n)


### PR DESCRIPTION
## Summary

Adds two new MCP tools optimized for frequent polling:

- **`status`** - Fast counters check (~100ms polling). Returns monotonic counters (spans/logs/metrics received), recent error count, generation counter for change detection, and uptime.

- **`recent_activity`** - Rich summary (1-5s polling). Returns recent 5 traces (deduplicated by service:rootSpan), recent 5 errors, throughput counters, and optional metric peek with histogram percentiles (p50/p95/p99).

## Implementation

- New `HUDCache` component with atomic counters for lock-free reads
- Trace deduplication by `service:rootSpan` to avoid repetitive entries
- Histogram percentile computation using linear interpolation (Prometheus-style)
- Integrated into storage layer receive paths

## Test plan

- [x] Unit tests for HUDCache operations
- [x] Unit tests for histogram percentile computation
- [x] Concurrency tests for atomic operations
- [x] Build passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)