### PR TITLE
Fix release: qemu-free arm64 builds and release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONFIG_MOUNT := $(if $(wildcard $(CONFIG_FILE)),-v "$(PWD)/$(CONFIG_FILE)":/etc/
 OTEL_IMAGE := otel/opentelemetry-collector:0.146.1
 IMAGE_NAME := otlp-mcp
 
-.PHONY: help build-local test fmt vet build run run-bg serve proxy release-snapshot
+.PHONY: help build-local test fmt vet build run run-bg serve proxy release-snapshot release
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -46,7 +46,10 @@ build: ## Build all-in-one Docker image (proxy + otlp-mcp)
 	docker build -t $(IMAGE_NAME) .
 
 release-snapshot: ## Build release artifacts locally (no push, no tag)
-	goreleaser release --snapshot --clean
+	goreleaser release --snapshot --clean --skip=docker
+
+release: ## Full release: binaries, packages, Docker images (requires git tag)
+	./release/do-release.sh
 
 run: ## Run all-in-one container (proxy + otlp-mcp)
 	@echo "Starting all-in-one container..."

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,18 +1,26 @@
-# Release Dockerfile for GoReleaser.
-# Binary is built by GoReleaser and copied in via COPY.
-# otelcol comes from the official multi-arch image — no qemu needed.
+# Release Dockerfile for GoReleaser / do-release.sh.
+# Go binary is cross-compiled externally. otelcol comes from the official
+# multi-arch image. No qemu needed — the only RUN is in a native-arch stage.
 
 FROM otel/opentelemetry-collector:0.146.1 AS otelcol
 
+# Create user files in a native-arch stage (avoids qemu for cross builds).
+# BUILDPLATFORM is always the host arch, so this RUN executes natively.
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} alpine:3.21 AS usersetup
+RUN addgroup -g 4317 -S otlp && adduser -u 4317 -S otlp -G otlp
+
+# Final image — no RUN, so --platform works without qemu.
 FROM alpine:3.21
 
 ARG TARGETPLATFORM
+
+COPY --from=usersetup /etc/passwd /etc/passwd
+COPY --from=usersetup /etc/group /etc/group
 COPY --from=otelcol /otelcol /usr/local/bin/otelcol
 COPY ${TARGETPLATFORM}/otlp-mcp /usr/local/bin/otlp-mcp
 COPY otel-config.yaml /etc/otel/config.yaml
 COPY entrypoint.sh /entrypoint.sh
-
-RUN addgroup -g 4317 -S otlp && adduser -u 4317 -S otlp -G otlp
 
 USER otlp
 

--- a/release/do-release.sh
+++ b/release/do-release.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Build and push a release of otlp-mcp.
+#
+# Prerequisites:
+#   - goreleaser (go install github.com/goreleaser/goreleaser/v2@latest)
+#   - podman (or docker)
+#   - logged into ghcr.io (echo $TOKEN | podman login ghcr.io -u USERNAME --password-stdin)
+#   - GITHUB_TOKEN set or ~/.gh-packages-key exists
+#
+# Usage:
+#   git tag v0.5.0
+#   git push origin v0.5.0
+#   ./release/do-release.sh
+
+set -eu
+
+REGISTRY="ghcr.io/tobert/otlp-mcp"
+PLATFORMS="linux/amd64 linux/arm64"
+
+# Resolve container runtime.
+if command -v podman >/dev/null 2>&1; then
+  CTR=podman
+elif command -v docker >/dev/null 2>&1; then
+  CTR=docker
+else
+  echo "Error: podman or docker required" >&2
+  exit 1
+fi
+
+# Resolve GitHub token.
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  if [ -f "$HOME/.gh-packages-key" ]; then
+    GITHUB_TOKEN=$(cat "$HOME/.gh-packages-key")
+    export GITHUB_TOKEN
+  else
+    echo "Error: GITHUB_TOKEN not set and ~/.gh-packages-key not found" >&2
+    exit 1
+  fi
+fi
+
+# Get version from latest git tag.
+TAG=$(git describe --tags --exact-match 2>/dev/null || true)
+if [ -z "$TAG" ]; then
+  echo "Error: HEAD is not tagged. Tag first: git tag v0.x.y" >&2
+  exit 1
+fi
+echo "==> Releasing ${TAG}"
+
+# Step 1: goreleaser builds binaries, packages, and creates GitHub release.
+echo "==> Running goreleaser..."
+goreleaser release --clean --skip=docker
+
+# Step 2: Set up Docker build context from goreleaser output.
+CONTEXT=$(mktemp -d)
+trap 'rm -rf "$CONTEXT"' EXIT
+
+cp dist/otlp-mcp_linux_amd64_v1/otlp-mcp "$CONTEXT/linux-amd64"
+cp dist/otlp-mcp_linux_arm64_v8.0/otlp-mcp "$CONTEXT/linux-arm64"
+cp otel-config.yaml entrypoint.sh "$CONTEXT/"
+cp release/Dockerfile "$CONTEXT/Dockerfile"
+
+# Create platform directories matching TARGETPLATFORM layout.
+mkdir -p "$CONTEXT/linux/amd64" "$CONTEXT/linux/arm64"
+cp "$CONTEXT/linux-amd64" "$CONTEXT/linux/amd64/otlp-mcp"
+cp "$CONTEXT/linux-arm64" "$CONTEXT/linux/arm64/otlp-mcp"
+
+# Step 3: Build per-arch images.
+echo "==> Building container images..."
+for PLAT in $PLATFORMS; do
+  ARCH_TAG="${TAG}-$(echo "$PLAT" | tr '/' '-')"
+  echo "    ${REGISTRY}:${ARCH_TAG}"
+  $CTR build \
+    --platform "$PLAT" \
+    --build-arg "TARGETPLATFORM=$PLAT" \
+    -f "$CONTEXT/Dockerfile" \
+    -t "${REGISTRY}:${ARCH_TAG}" \
+    "$CONTEXT"
+done
+
+# Step 4: Push per-arch images.
+echo "==> Pushing images..."
+for PLAT in $PLATFORMS; do
+  ARCH_TAG="${TAG}-$(echo "$PLAT" | tr '/' '-')"
+  $CTR push "${REGISTRY}:${ARCH_TAG}"
+done
+
+# Step 5: Create and push multi-arch manifest.
+echo "==> Creating manifest ${REGISTRY}:${TAG}..."
+$CTR manifest create "${REGISTRY}:${TAG}" \
+  "${REGISTRY}:${TAG}-linux-amd64" \
+  "${REGISTRY}:${TAG}-linux-arm64"
+$CTR manifest push "${REGISTRY}:${TAG}" "docker://${REGISTRY}:${TAG}"
+
+echo "==> Creating manifest ${REGISTRY}:latest..."
+$CTR manifest create "${REGISTRY}:latest" \
+  "${REGISTRY}:${TAG}-linux-amd64" \
+  "${REGISTRY}:${TAG}-linux-arm64"
+$CTR manifest push "${REGISTRY}:latest" "docker://${REGISTRY}:latest"
+
+echo "==> Done! Release ${TAG} published."
+echo "    GitHub: https://github.com/tobert/otlp-mcp/releases/tag/${TAG}"
+echo "    Docker: ${REGISTRY}:${TAG}"


### PR DESCRIPTION
## Summary
- Fix arm64 Docker builds without qemu by using a `BUILDPLATFORM` stage for user creation
- Add `release/do-release.sh` — end-to-end release script (goreleaser + multi-arch Docker + ghcr.io manifest)
- Add `make release` target, fix `make release-snapshot` to skip docker

## Problem
v0.4.0 Docker release was amd64-only because `RUN addgroup` in the release Dockerfile requires executing arm64 binaries (qemu). The fix moves user creation to a native-arch build stage — the final image has only `COPY` and `USER`, no `RUN`.

## Test plan
- [x] `go test ./...` passes
- [x] arm64 Docker image builds without qemu on amd64 host
- [x] amd64 Docker image still builds correctly
- [ ] Full `make release` after tagging v0.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)