### PR TITLE
Fix BUILDPLATFORM for podman

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -6,7 +6,7 @@ FROM otel/opentelemetry-collector:0.146.1 AS otelcol
 
 # Create user files in a native-arch stage (avoids qemu for cross builds).
 # BUILDPLATFORM is always the host arch, so this RUN executes natively.
-ARG BUILDPLATFORM=linux/amd64
+ARG BUILDPLATFORM
 FROM --platform=${BUILDPLATFORM} alpine:3.21 AS usersetup
 RUN addgroup -g 4317 -S otlp && adduser -u 4317 -S otlp -G otlp
 

--- a/release/do-release.sh
+++ b/release/do-release.sh
@@ -65,12 +65,21 @@ cp "$CONTEXT/linux-amd64" "$CONTEXT/linux/amd64/otlp-mcp"
 cp "$CONTEXT/linux-arm64" "$CONTEXT/linux/arm64/otlp-mcp"
 
 # Step 3: Build per-arch images.
-echo "==> Building container images..."
+# BUILDPLATFORM tells the Dockerfile which arch can run RUN natively.
+BUILD_ARCH="$(uname -m)"
+case "$BUILD_ARCH" in
+  x86_64)  BUILD_PLAT="linux/amd64" ;;
+  aarch64) BUILD_PLAT="linux/arm64" ;;
+  *)       BUILD_PLAT="linux/amd64" ;;
+esac
+
+echo "==> Building container images (build platform: ${BUILD_PLAT})..."
 for PLAT in $PLATFORMS; do
   ARCH_TAG="${TAG}-$(echo "$PLAT" | tr '/' '-')"
   echo "    ${REGISTRY}:${ARCH_TAG}"
   $CTR build \
     --platform "$PLAT" \
+    --build-arg "BUILDPLATFORM=$BUILD_PLAT" \
     --build-arg "TARGETPLATFORM=$PLAT" \
     -f "$CONTEXT/Dockerfile" \
     -t "${REGISTRY}:${ARCH_TAG}" \


### PR DESCRIPTION
Podman rejects `ARG BUILDPLATFORM=default` since it's a reserved built-in. Detect host arch in do-release.sh and pass it explicitly.

Follow-up to #18 — discovered during v0.4.1 Docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)